### PR TITLE
Try to increase number of (sync) workers

### DIFF
--- a/analytics_platform/kronos/scripts/entrypoint.sh
+++ b/analytics_platform/kronos/scripts/entrypoint.sh
@@ -6,7 +6,7 @@
 
 zip -r /tmp/training.zip /analytics_platform /util
 
-gunicorn --pythonpath / -b 0.0.0.0:$SERVICE_PORT -t $SERVICE_TIMEOUT rest_api:app
+gunicorn --pythonpath / -b 0.0.0.0:$SERVICE_PORT --workers=10 -t $SERVICE_TIMEOUT rest_api:app
 
 # --------------------------------------------------------------------------------------------------
 # to make the container alive for indefinite time

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -57,14 +57,14 @@ objects:
               port: 6006
             initialDelaySeconds: 15
             periodSeconds: 60
-            timeoutSeconds: 15
+            timeoutSeconds: 30
           readinessProbe:
             httpGet:
               path: /
               port: 6006
             initialDelaySeconds: 15
             periodSeconds: 60
-            timeoutSeconds: 15
+            timeoutSeconds: 30
           resources:
             requests:
               cpu: ${CPU_REQUEST}


### PR DESCRIPTION
My theory:

Default number of workers is 1 and since it takes a lot of time for single request to finish, noone else can talk to the service in that time. Not even OpenShift which tries to check whether the service is still alive (liveness probe). Since the service is busy processing requests from users, it doesn't respond to liveness checks and therefore OpenShift eventually decides to kill and recreate the container. This would explain following behaviour:

```shell
$ curl -vvv --max-time 900 -XPOST -H 'Content-Type: application/json' -d '[{"ecosystem": "pypi","comp_package_count_threshold": 2,"alt_package_count_threshold": 4,"outlier_probability_threshold": 0.8,"unknown_packages_ratio_threshold": 0.3,"package_list": ["requests","scikit-learn","coverage","cycler","numpy","mock","nose","scipy","matplotlib","nltk","pandas"]}]'  http://bayesian-kronos-pypi:6006/api/v1/schemas/kronos_scoring
* About to connect() to bayesian-kronos-pypi port 6006 (#0)
*   Trying 172.30.238.172...
* Connected to bayesian-kronos-pypi (172.30.238.172) port 6006 (#0)
> POST /api/v1/schemas/kronos_scoring HTTP/1.1
> User-Agent: curl/7.29.0
> Host: bayesian-kronos-pypi:6006
> Accept: */*
> Content-Type: application/json
> Content-Length: 290
> 
* upload completely sent off: 290 out of 290 bytes
* Empty reply from server
* Connection #0 to host bayesian-kronos-pypi left intact
curl: (52) Empty reply from server
```

Note this is not a proper fix. It would be probably better to use async workers. This is just to test whether my theory is right or not.