### PR TITLE
Moved pomegranate to requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN yum install -y epel-release && \
 # --------------------------------------------------------------------------------------------------
 COPY ./analytics_platform/kronos/requirements.txt /
 RUN pip install -r /requirements.txt && rm /requirements.txt
-RUN pip install pomegranate==0.7.3
 
 
 

--- a/analytics_platform/kronos/requirements.txt
+++ b/analytics_platform/kronos/requirements.txt
@@ -15,3 +15,4 @@ scipy==0.19.0
 botocore==1.5.32
 pandas
 gevent
+pomegranate==0.7.3


### PR DESCRIPTION
It's kind of a nuisance when setting up this repository for development to manually look up the version of `pomegranate` in the `Dockerfile` and install it separately. Added it to requirements, didn't see a reason why it was being installed separately.