### PR TITLE
Test data for unknown packages unit test

### DIFF
--- a/tests/data/data_gnosis/input-ptm-manifest-data/data_input_manifest_file_list/manifest_unknown_packages.json
+++ b/tests/data/data_gnosis/input-ptm-manifest-data/data_input_manifest_file_list/manifest_unknown_packages.json
@@ -1,0 +1,17 @@
+[
+  {
+    "ecosystem": "pypi",
+    "package_list": [
+      [
+        "tox",
+        "pytest",
+        "mock",
+        "pytest-cov",
+        "pytest-httpbin",
+        "docutils",
+        "wheel",
+        "distutils"
+      ]
+    ]
+  }
+]


### PR DESCRIPTION
There's a unit test that's currently failing as this file was missing in the code. Since they've not yet been integrated into the CI this went unnoticed.