### PR TITLE
Change part of name tagging to use worpunct_tokenize

### DIFF
--- a/analytics_platform/kronos/gnosis/src/gnosis_package_topic_model.py
+++ b/analytics_platform/kronos/gnosis/src/gnosis_package_topic_model.py
@@ -1,5 +1,7 @@
 from analytics_platform.kronos.gnosis.src.abstract_gnosis import AbstractGnosis
 from analytics_platform.kronos.gnosis.src.gnosis_constants import *
+from nltk.tokenize import wordpunct_tokenize
+import string
 
 
 class GnosisPackageTopicModel(AbstractGnosis):
@@ -134,13 +136,20 @@ class GnosisPackageTopicModel(AbstractGnosis):
         """Create tags for a package based on its name"""
         tags = []
         name_parts = package_name.split(":")[:2]
-        for name_part in name_parts:
-            # Exclude common parts of the package name that are not
-            # useful as tags
-            tags += [
-                GNOSIS_PTM_TOPIC_PREFIX + tag.lower()
-                for tag in name_part.split('.') if
-                tag and tag != 'com' and tag != 'org' and tag != 'io'
-            ]
+
+        if len(name_parts) > 1:
+            # ecosystem is maven, at least based on naming scheme
+            tags_artifact = [tag for tag in wordpunct_tokenize(name_parts[1]) if
+                             tag not in string.punctuation]
+            tags_group = [tag for tag in wordpunct_tokenize(name_parts[0]) if
+                          tag not in string.punctuation and tag not in
+                          ['org', 'com', 'io', 'ch', 'cn']]
+            print(tags_group)
+            tags = set(tags_artifact + tags_group)
+        else:
+            # return the tokenized package name
+            tags = set([tag for tag in wordpunct_tokenize(package_name)
+                        if tag not in string.punctuation])
+        tags = [GNOSIS_PTM_TOPIC_PREFIX + tag.lower() for tag in tags][:GNOSIS_PTM_TAG_LIMIT]
         # Make sure there are no duplicates
-        return set(tags[:GNOSIS_PTM_TAG_LIMIT])
+        return set(tags)

--- a/analytics_platform/kronos/gnosis/src/gnosis_package_topic_model.py
+++ b/analytics_platform/kronos/gnosis/src/gnosis_package_topic_model.py
@@ -144,7 +144,6 @@ class GnosisPackageTopicModel(AbstractGnosis):
             tags_group = [tag for tag in wordpunct_tokenize(name_parts[0]) if
                           tag not in string.punctuation and tag not in
                           ['org', 'com', 'io', 'ch', 'cn']]
-            print(tags_group)
             tags = set(tags_artifact + tags_group)
         else:
             # return the tokenized package name

--- a/analytics_platform/kronos/requirements.txt
+++ b/analytics_platform/kronos/requirements.txt
@@ -15,3 +15,4 @@ scipy==0.19.0
 botocore==1.5.32
 pandas
 gevent
+nltk==3.2.5

--- a/analytics_platform/kronos/scripts/bootstrap_action.sh
+++ b/analytics_platform/kronos/scripts/bootstrap_action.sh
@@ -4,7 +4,7 @@
 # this script will be executed by aws spark emr during bootstrap process of each node
 # we install python dependencies of our training job here
 # --------------------------------------------------------------------------------------------------
-sudo pip install cython pomegranate uuid boto3 boto pandas sklearn numpy scipy psutil
+sudo pip install cython pomegranate uuid boto3 boto pandas sklearn numpy scipy psutil nltk
 
 #wget -P /tmp https://github.com/pgmpy/pgmpy/archive/dev.zip
 #cd /tmp


### PR DESCRIPTION
We noticed that a lot of packages in maven have artifact names
of the form "something-metrics-dashboard" where the parts
of name make perfectly good tags.

We had introduced a tokenizer within the PGM itself to make sure
training does not fail due to a couple of packages missing their tags.

Combining both these approaches, I've changed the tokenizer
previously in use to tokenizer parts of the artifact and group name.