### PR TITLE
Fix adding of ntlk

### DIFF
--- a/analytics_platform/kronos/scripts/bootstrap_action.sh
+++ b/analytics_platform/kronos/scripts/bootstrap_action.sh
@@ -4,7 +4,8 @@
 # this script will be executed by aws spark emr during bootstrap process of each node
 # we install python dependencies of our training job here
 # --------------------------------------------------------------------------------------------------
-sudo pip install cython pomegranate uuid boto3 boto pandas sklearn numpy scipy psutil nltk
+sudo pip install cython pomegranate uuid boto3 boto pandas sklearn numpy scipy psutil
+sudo pip install nltk
 
 #wget -P /tmp https://github.com/pgmpy/pgmpy/archive/dev.zip
 #cd /tmp


### PR DESCRIPTION
The previous change in `bootstrap.sh` is causing the following error while traning on EMR
```
2017-10-31 13:18:52,238 INFO i-03b9ec72e9ab5c2c8: new instance started
2017-10-31 13:22:54,830 ERROR i-03b9ec72e9ab5c2c8: failed to start. bootstrap action 1 failed with non-zero exit code.

```