### PR TITLE
Unit test integration in the CI pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,13 @@
-FROM centos:7
-MAINTAINER Avishkar Gupta <avgupta@redhat.com>
-
-ENV LANG=en_US.UTF-8
-
-RUN yum install -y epel-release && \
-    yum install -y zip && \
-    yum install -y python-pip python-devel gcc && \
-    yum -y install tkinter && \
-    yum-config-manager --disable testing-devtools-2-centos-7 && \
-    yum -y install gcc-c++.x86_64 && \
-    yum clean all
-
+FROM registry.devshift.net/fabric8-analytics/f8a-kronos-base:latest
+LABEL maintainer="Avishkar Gupta <avgupta@redhat.com>"
 
 # --------------------------------------------------------------------------------------------------
 # install python packages
 # --------------------------------------------------------------------------------------------------
 COPY ./analytics_platform/kronos/requirements.txt /
+# To accomodate for any additional requirements that are not
+# added to base for some reason, ex: local testing.
 RUN pip install -r /requirements.txt && rm /requirements.txt
-RUN pip install pomegranate==0.7.3
-
 
 # --------------------------------------------------------------------------------------------------
 # copy src code and scripts into root dir /

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -13,7 +13,7 @@ RUN yum install -y java-1.8.0-openjdk.x86_64 java-1.8.0-openjdk-devel.x86_64 wge
     wget https://downloads.lightbend.com/scala/2.12.2/scala-2.12.2.tgz && \
     tar -xvf scala-2.12.2.tgz && \
     mv scala-2.12.2 /usr/local/scala && \
-    wget https://d3kbcqa49mib13.cloudfront.net/spark-2.1.1-bin-hadoop2.7.tgz && \
+    wget https://archive.apache.org/dist/spark/spark-2.1.1/spark-2.1.1-bin-hadoop2.7.tgz && \
     tar -xvf spark-2.1.1-bin-hadoop2.7.tgz && \
     mv spark-2.1.1-bin-hadoop2.7 /usr/local/spark
 

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,0 +1,31 @@
+FROM registry.devshift.net/bayesian/kronos:latest
+MAINTAINER Avishkar Gupta <avgupta@redhat.com>
+
+# --------------------------------------------------------------------------------------------------
+# copy testing source code and scripts into root dir /
+# --------------------------------------------------------------------------------------------------
+ADD ./tests/ /tests
+ADD ./tests/scripts/entrypoint-test.sh /entrypoint-test.sh
+RUN chmod +x /entrypoint-test.sh
+
+# Begin spark installation
+RUN yum install -y java-1.8.0-openjdk.x86_64 java-1.8.0-openjdk-devel.x86_64 wget && \
+    wget https://downloads.lightbend.com/scala/2.12.2/scala-2.12.2.tgz && \
+    tar -xvf scala-2.12.2.tgz && \
+    mv scala-2.12.2 /usr/local/scala && \
+    wget https://d3kbcqa49mib13.cloudfront.net/spark-2.1.1-bin-hadoop2.7.tgz && \
+    tar -xvf spark-2.1.1-bin-hadoop2.7.tgz && \
+    mv spark-2.1.1-bin-hadoop2.7 /usr/local/spark
+
+RUN export java_version="`ls /usr/lib/jvm` | grep java-1.8.0-openjdk-"
+RUN export JAVA_HOME="/usr/lib/jvm/${java_version}/jre"
+ENV SPARK_HOME=/usr/local/spark
+ENV PATH=/usr/local/maven/bin:$JAVA_HOME/bin:$SPARK_HOME/bin:/usr/local/scala/bin:$PATH
+ENV PYTHONPATH=/
+
+RUN python -m pip install pytest py4j
+
+# --------------------------------------------------------------------------------------------------
+# RUN THE UNIT TESTS
+# --------------------------------------------------------------------------------------------------
+ENTRYPOINT ["/entrypoint-test.sh"]

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ all: fast-docker-build
 docker-build:
 	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) .
 
+docker-build-test: docker-build
+	docker build --no-cache -t kronos-tests -f Dockerfile.tests .
+
 fast-docker-build:
 	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) .
 

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -5,5 +5,5 @@ set -ex
 . cico_setup.sh
 
 build_image
-./runtest.sh
+CI=1 ./runtest.sh
 push_image

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -5,5 +5,5 @@ set -ex
 . cico_setup.sh
 
 build_image
-
+./runtest.sh
 push_image

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -17,7 +17,8 @@ prep() {
 }
 
 build_image() {
-    make docker-build
+    # Also runs the recipe for docker-build
+    make docker-build-test
 }
 
 tag_push() {

--- a/runtest.sh
+++ b/runtest.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+TEST_IMAGE_NAME='kronos-tests'
+docker run ${TEST_IMAGE_NAME}

--- a/runtest.sh
+++ b/runtest.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
 
 TEST_IMAGE_NAME='kronos-tests'
-docker run ${TEST_IMAGE_NAME}
+
+gc() {
+    docker rmi -f `make get-image-name`
+    docker rmi -f ${TEST_IMAGE_NAME}
+}
+
+if [[ "$CI" -eq "0" ]];
+then
+    make docker-build-test
+    docker run ${TEST_IMAGE_NAME}
+    docker stop ${TEST_IMAGE_NAME}
+    trap gc EXIT SIGINT
+else
+    # CI instance will be torn down anyway, don't need to waste time on gc
+    docker run ${TEST_IMAGE_NAME}
+fi

--- a/tests/scripts/entrypoint-test.sh
+++ b/tests/scripts/entrypoint-test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+python -m pytest /tests/unit_tests/

--- a/tests/unit_tests/test_apollo_tag_prune.py
+++ b/tests/unit_tests/test_apollo_tag_prune.py
@@ -1,9 +1,8 @@
 from analytics_platform.kronos.src import config
 from util.data_store.local_filesystem import LocalFileSystem
 from analytics_platform.kronos.apollo.src.apollo_tag_prune import TagListPruner
-from analytics_platform.kronos.apollo.src.apollo_constants import
-PACKAGE_LIST_INPUT_CURATED_FILEPATH
-
+from analytics_platform.kronos.apollo.src.apollo_constants import (
+        PACKAGE_LIST_INPUT_CURATED_FILEPATH)
 from unittest import TestCase
 
 


### PR DESCRIPTION
Okay, so Spark installation doesn't take as long as I thought it would, however the bottleneck in building all of this is the Kronos image build itself since it has a lot of Cpython/C/Fortran code in the numpy/scipy suite and Pomegranate that needs to build wheel on the container.

Is it possible for us to push to a 'pomegranate' base image to registry.devshift, that contains all the Python dependencies for Kronos in it? That way we reduce the time it takes to build Kronos and in turn the time taken by the CI pipeline.