### PR TITLE
Remove gevent as worker class to remove nested multiprocessing

### DIFF
--- a/analytics_platform/kronos/requirements.txt
+++ b/analytics_platform/kronos/requirements.txt
@@ -14,7 +14,6 @@ boto3==1.4.4
 scipy==0.19.0
 botocore==1.5.32
 pandas==0.19.2
-gevent==1.2.2
 nltk==3.2.5
 daiquiri==1.3.0
 six==1.11.0

--- a/analytics_platform/kronos/scripts/entrypoint.sh
+++ b/analytics_platform/kronos/scripts/entrypoint.sh
@@ -7,7 +7,8 @@
 zip -r /tmp/training.zip /analytics_platform /util
 zip -r /tmp/tagging.zip /tagging_platform /util /analytics_platform
 
-gunicorn --pythonpath / -b 0.0.0.0:$SERVICE_PORT --workers=2 -k gevent -t $SERVICE_TIMEOUT rest_api:app
+# WARNING: Don't add worker class as gevent since it doesn't allow PGM to perform scoring in parallel
+gunicorn --pythonpath / -b 0.0.0.0:$SERVICE_PORT --workers=2 -t $SERVICE_TIMEOUT rest_api:app
 
 # --------------------------------------------------------------------------------------------------
 # to make the container alive for indefinite time


### PR DESCRIPTION
Gevent spans a new process for every worker and since PGM also performs scoring in [parallel](https://github.com/fabric8-analytics/fabric8-analytics-stack-analysis/blob/master/analytics_platform/kronos/pgm/src/pgm_pomegranate.py#L82-L86), it results into nested multiprocessing which isn't supported by joblib. According to this joblib [issue](https://github.com/joblib/joblib/issues/180), it converts nested calls into sequential code which defeats the whole purpose of multiprocessing and doesn't allow PGM to perform the scoring in parallel which in turn makes PGM much slower. 

By removing gevent, PGM is now able to span multiple processes and hence the scoring is approximately 4-5 times faster than the original one. :tada: 