### PR TITLE
Fixed gnosis package topic model generation overwrite bug

### DIFF
--- a/analytics_platform/kronos/gnosis/src/gnosis_package_topic_model.py
+++ b/analytics_platform/kronos/gnosis/src/gnosis_package_topic_model.py
@@ -67,8 +67,9 @@ class GnosisPackageTopicModel(AbstractGnosis):
                     topic_list]
                 distinct_formatted_topic_list = set(
                     formatted_topic_list)
-                package_to_topic_dict[formatted_package] = list(
-                    distinct_formatted_topic_list)
+                package_to_topic_dict[formatted_package] = package_to_topic_dict.get(formatted_package,
+                                                                                     []) or \
+                                                           list(distinct_formatted_topic_list)
 
                 for formatted_topic in distinct_formatted_topic_list:
                     if formatted_topic not in topic_to_package_dict:

--- a/analytics_platform/kronos/gnosis/src/gnosis_package_topic_model.py
+++ b/analytics_platform/kronos/gnosis/src/gnosis_package_topic_model.py
@@ -67,9 +67,8 @@ class GnosisPackageTopicModel(AbstractGnosis):
                     topic_list]
                 distinct_formatted_topic_list = set(
                     formatted_topic_list)
-                package_to_topic_dict[formatted_package] = package_to_topic_dict.get(formatted_package,
-                                                                                     []) or \
-                                                           list(distinct_formatted_topic_list)
+                package_to_topic_dict[formatted_package] = package_to_topic_dict.get(
+                    formatted_package, []) or list(distinct_formatted_topic_list)
 
                 for formatted_topic in distinct_formatted_topic_list:
                     if formatted_topic not in topic_to_package_dict:


### PR DESCRIPTION
If we have two packages of the form:

"mysql:mysql-connector-java": ['tag1', 'tag2']
"MySql:mysql-connector-java": []

Then the auto generated tags from the part of name tagger overwrite the first. as they're both mapped to the same lowercase key.