### PR TITLE
Remove companion thresholding before filter and retrain

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,4 +159,4 @@ BODY: JSON data
 ## Latest Depolyment
 
 * Maven
-	* Retrained on: 2017-11-29 02:30 (UTC+5:30)
+	* Retrained on: 2018-01-02 21:30 (UTC+5:30)

--- a/analytics_platform/kronos/src/kronos_online_scoring.py
+++ b/analytics_platform/kronos/src/kronos_online_scoring.py
@@ -225,8 +225,7 @@ def score_kronos(kronos, requested_package_list, kronos_dependency, comp_package
             package_list=package_list,
             non_companion_packages=non_companion_packages)
 
-        companion_package_dict_list_pruned = companion_package_dict_list[
-                                             0:comp_package_count_threshold]
+        companion_package_dict_list_pruned = companion_package_dict_list[:]
 
         companion_package_dict_same_name_pruned = \
             [companion_package for companion_package in companion_package_dict_list_pruned


### PR DESCRIPTION
There's already a thresholding step implemented in the post-processing
filters where we only choose the top three companion recommendations.
The current model is using 2-itemsets and works for all the quickstarts
when coupled with the changes in data.