### PR TITLE
Remove pickling of model

### DIFF
--- a/analytics_platform/kronos/pgm/src/pgm_pomegranate.py
+++ b/analytics_platform/kronos/pgm/src/pgm_pomegranate.py
@@ -5,7 +5,6 @@ import analytics_platform.kronos.pgm.src.pgm_constants as pgm_constants
 import util.pgm_util as utils
 from util.data_store.local_filesystem import LocalFileSystem
 from util.data_store.s3_data_store import S3DataStore
-import pickle
 from joblib import Parallel, delayed
 import functools
 
@@ -38,7 +37,7 @@ class PGMPomegranate(AbstractPGM):
             with open(local_filename, 'wb') as f:
                 # IMPORTANT: Set pickle.HIGHEST_PROTOCOL only  after complete porting to
                 # Python3
-                pickle.dump(pgm_model.to_json(), f, protocol=2)
+                f.write(pgm_model.to_json())
 
             data_store.upload_file(local_filename, filename)
         return None
@@ -52,7 +51,7 @@ class PGMPomegranate(AbstractPGM):
             local_filename = "/tmp/kronos.json"
             data_store.download_file(filename, local_filename)
             with open(local_filename, 'rb') as f:
-                pgm_model = BayesianNetwork.from_json(pickle.load(f))
+                pgm_model = BayesianNetwork.from_json(f.read())
         return PGMPomegranate(pgm_model)
 
     @classmethod


### PR DESCRIPTION
The model is already being converted to a JSON(using the `to_json`)
function of pomegranate which is already a stadard serialized format.
I don't see a need to further serialize the JSON using pickle to
something that can be loaded only using Python. This also helps us
reduce the training time of the model as pickling and unpickling
has a overhead that I don't see a need for, because JSON.