### PR TITLE
Add docker-compose.yml for local deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 *.pyc
+.env
 env/
 venv/
 cache/
 config.py
-docker-compose*
 error.log
 *.ipynb
 derby.log

--- a/README.md
+++ b/README.md
@@ -9,6 +9,27 @@
 * [Apollo](/analytics_platform/kronos/apollo)
 * [Uranus](/analytics_platform/kronos/uranus)
 
+## To Deploy Locally
+Set up .env file with environment variables, i.e
+```bash
+cat > .env <<-EOF
+# Amazon AWS s3 credentials
+AWS_S3_ACCESS_KEY_ID=$CUSTOM_KEY
+AWS_S3_SECRET_ACCESS_KEY=$CUSTOM_SECRET_KEY
+
+# Kronos environment
+KRONOS_SCORING_REGION=$CUSTOM_ECOSYSTEM  # <maven/pypi/npm>
+DEPLOYMENT_PREFIX=$DEPL_PREFIX  # <dev/stage/prod>
+GREMLIN_REST_URL=$GREMLIN_URL  # <url>:<port>
+EOF
+```
+
+Deploy with docker-compose
+```bash
+docker-compose build
+docker-compose up
+```
+
 ## To Test Locally
 
 `python -m unittest discover tests  -v`

--- a/README.md
+++ b/README.md
@@ -10,24 +10,40 @@
 * [Uranus](/analytics_platform/kronos/uranus)
 
 ## To Deploy Locally
-Set up .env file with environment variables, i.e
+Set up .env file with environment variables, i.e (view docker-compose.yml for possible values)
 ```bash
 cat > .env <<-EOF
 # Amazon AWS s3 credentials
-AWS_S3_ACCESS_KEY_ID=$CUSTOM_KEY
-AWS_S3_SECRET_ACCESS_KEY=$CUSTOM_SECRET_KEY
+AWS_S3_ACCESS_KEY_ID=
+AWS_S3_SECRET_ACCESS_KEY=
 
 # Kronos environment
-KRONOS_SCORING_REGION=$CUSTOM_ECOSYSTEM  # <maven/pypi/npm>
-DEPLOYMENT_PREFIX=$DEPL_PREFIX  # <dev/stage/prod>
-GREMLIN_REST_URL=$GREMLIN_URL  # <url>:<port>
+KRONOS_SCORING_REGION=
+DEPLOYMENT_PREFIX=
+GREMLIN_REST_URL=
 EOF
 ```
 
-Deploy with docker-compose
+[data-model]: https://github.com/fabric8-analytics/fabric8-analytics-data-model/tree/master/local-setup
+**NOTES:**\
+Do *not* use any `[#]` comments or `['"]` in the .env file.\
+For the `GREMLIN_REST_URL`, you can take a look at out [data-model]
+and use the local-setup services
+```bash
+git clone https://github.com/fabric8-analytics/fabric8-analytics-data-model.git
+cp -r fabric8-analytics-data-model/local-setup/scripts .
+cp fabric8-analytics-data-model/local-setup/docker-compose.yml docker-compose-data-model.yml
+
+# and in .env file
+GREMLIN_REST_URL="http://localhost:8182"  # Note that the port is a port accessed from within the container
+```
+Otherwise you can use custom gremlin service
+
+Deploy with docker-compose:\
+
 ```bash
 docker-compose build
-docker-compose up
+docker-compose -f docker-compose.yml -f docker-compose-data-model.yml up
 ```
 
 ## To Test Locally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3"
+services:
+  kronos:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: kronos:latest
+    network_mode: bridge
+    entrypoint:
+      - /bin/entrypoint.sh
+    environment:
+      AWS_S3_ACCESS_KEY_ID: "${AWS_S3_ACCESS_KEY_ID}"
+      AWS_S3_SECRET_ACCESS_KEY: "${AWS_S3_SECRET_ACCESS_KEY}"
+      KRONOS_SCORING_REGION: "${KRONOS_SCORING_REGION}"  # [ECOSYSTEM] - <maven/pypi/npm>
+      DEPLOYMENT_PREFIX: "${DEPLOYMENT_PREFIX}"  # <DEV/STAGE/PROD> - affects where the data and log for training gets stored.
+      SERVICE_PORT: "6006"
+      SERVICE_TIMEOUT: "900"
+      SPARK_HOME: "/usr/local/spark"
+      PY4J_VERSION: "py4j-0.10.4-src.zip"
+      GREMLIN_REST_URL: "http://bayesian-gremlin-http-preview-b6ff-bayesian-preview.b6ff.rh-idev.openshiftapps.com"  # <url>:<port>
+      FLASK_LOGGING_LEVEL: "DEBUG"
+    ports:
+        - "6006:6006"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2"
 services:
   kronos:
     build:
@@ -17,7 +17,7 @@ services:
       SERVICE_TIMEOUT: "900"
       SPARK_HOME: "/usr/local/spark"
       PY4J_VERSION: "py4j-0.10.4-src.zip"
-      GREMLIN_REST_URL: "http://bayesian-gremlin-http-preview-b6ff-bayesian-preview.b6ff.rh-idev.openshiftapps.com"  # <url>:<port>
-      FLASK_LOGGING_LEVEL: "DEBUG"
+      GREMLIN_REST_URL: "${GREMLIN_REST_URL}"  # <url>:<port>
+      # FLASK_LOGGING_LEVEL: "DEBUG"
     ports:
         - "6006:6006"


### PR DESCRIPTION
- use .env file to set up environment variables and credentials
- add .env file to .gitignore to prevent commiting private credentials

- modify README.md with instructions for local deployment

Signed-off-by: Marek Cermak <macermak@redhat.com>

new file:   docker-compose.yml
modified:   .gitignore
modified:   README.md