### PR TITLE
Remove logging from PGM

### DIFF
--- a/analytics_platform/kronos/pgm/src/pgm_pomegranate.py
+++ b/analytics_platform/kronos/pgm/src/pgm_pomegranate.py
@@ -83,7 +83,7 @@ class PGMPomegranate(AbstractPGM):
         n_jobs = len(evidence_dict_list)
         result_array = functools.reduce(
             list.__add__,
-            Parallel(n_jobs=n_jobs, verbose=51)(
+            Parallel(n_jobs=n_jobs)(
                 delayed(parallel_predict)([evidence_dict_list[i]]) for i in range(n_jobs))
         )
         return result_array


### PR DESCRIPTION
Since PGM is now tested on production with new outlier logic in place, logging is not needed anymore. Resolves https://github.com/openshiftio/openshift.io/issues/1785. 