### PR TITLE
Add build status icon to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Stack Analysis
+# Stack Analysis 
+
+[![Build Status](https://ci.centos.org/buildStatus/icon?job=devtools-fabric8-analytics-stack-analysis-f8a-build-master)](https://ci.centos.org/job/devtools-fabric8-analytics-stack-analysis-f8a-build-master/)
+
 
 ## List of models currently present in the analytics platform
 


### PR DESCRIPTION
Rather than navigating all the way to cico to check whether end to end tests have passed it's more convenient to have this icon here, it will change to "failing" if the end to end tests fail as the build-master job on cico invokes the end to end test flow.