### PR TITLE
Introduce OpenShift template with restart policy set to Never

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,8 @@
+# Deployment
+
+There are two OpenShift template files in this directory:
+
+* `template.yaml` - template for development purposes. It instantiates Kronos as a Pod with `restartPolicy` set to `Never`. This is needed as the service can be unstable and restarts can be expensive. Developers can recreate the Pod, if needed.
+`deploy.sh` script can be used to deploy the service.
+
+* `template-prod.yaml` - template used by [saas-herder](https://github.com/openshiftio/saasherder) to deploy the service to staging and production.

--- a/openshift/deploy.sh
+++ b/openshift/deploy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/bash -e
+
+set -x
+oc whoami
+oc project
+set +x
+
+function oc_process_apply() {
+  echo -e "\n Processing template - $1 ($2) \n"
+  oc process -f $1 $2 | oc apply -f -
+}
+
+here=`dirname $0`
+template="${here}/template.yaml"
+
+oc_process_apply "$template" "-p KRONOS_SCORING_REGION=maven"

--- a/openshift/template-prod.yaml
+++ b/openshift/template-prod.yaml
@@ -1,0 +1,164 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: bayesian-kronos
+metadata:
+  name: bayesian-kronos
+  annotations:
+    description: bayesian-kronos
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      service: bayesian-kronos-${KRONOS_SCORING_REGION}
+    name: bayesian-kronos-${KRONOS_SCORING_REGION}
+  spec:
+    replicas: "${{REPLICAS}}"
+    selector:
+      service: bayesian-kronos-${KRONOS_SCORING_REGION}
+    template:
+      metadata:
+        labels:
+          service: bayesian-kronos-${KRONOS_SCORING_REGION}
+      spec:
+        restartPolicy: ${RESTART_POLICY}
+        containers:
+        - command:
+          - /bin/entrypoint.sh
+          env:
+          - name: DEPLOYMENT_PREFIX
+            valueFrom:
+              configMapKeyRef:
+                name: bayesian-config
+                key: deployment-prefix
+          - name: SERVICE_PORT
+            value: "6006"
+          - name: SERVICE_TIMEOUT
+            value: "900"
+          - name: KRONOS_SCORING_REGION
+            value: "${KRONOS_SCORING_REGION}"
+          - name: USE_FILTERS
+            value: "${{USE_FILTERS}}"
+          - name: AWS_S3_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: s3-access-key-id
+                name: aws
+          - name: AWS_S3_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: s3-secret-access-key
+                name: aws
+          - name: FLASK_LOGGING_LEVEL
+            value: ${FLASK_LOGGING_LEVEL}
+          name: bayesian-kronos
+          image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
+          ports:
+          - containerPort: 6006
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 6006
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            timeoutSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 6006
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            timeoutSeconds: 30
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      service: bayesian-kronos-${KRONOS_SCORING_REGION}
+    name: bayesian-kronos-${KRONOS_SCORING_REGION}
+  spec:
+    ports:
+    - port: 6006
+      targetPort: 0
+    selector:
+      service: bayesian-kronos-${KRONOS_SCORING_REGION}
+
+parameters:
+- description: CPU request
+  displayName: CPU request
+  required: true
+  name: CPU_REQUEST
+  value: "500m"
+
+- description: CPU limit
+  displayName: CPU limit
+  required: true
+  name: CPU_LIMIT
+  value: "1000m"
+
+- description: Memory request
+  displayName: Memory request
+  required: true
+  name: MEMORY_REQUEST
+  value: "1024Mi"
+
+- description: Memory limit
+  displayName: Memory limit
+  required: true
+  name: MEMORY_LIMIT
+  value: "2048Mi"
+
+- description: Docker registry where the image is
+  displayName: Docker registry
+  required: true
+  name: DOCKER_REGISTRY
+  value: "registry.devshift.net"
+
+- description: Docker image to use
+  displayName: Docker image
+  required: true
+  name: DOCKER_IMAGE
+  value: "bayesian/kronos"
+
+- description: Image tag
+  displayName: Image tag
+  required: true
+  name: IMAGE_TAG
+  value: "latest"
+
+- description: Kronos Scoring Region - pypi or maven
+  displayName: Kronos Scoring Region
+  required: true
+  name: KRONOS_SCORING_REGION
+  value: "pypi"
+
+- description: "Flask logging level (see: https://docs.python.org/3/library/logging.html#levels)"
+  displayName: Flask logging level
+  required: false
+  name: FLASK_LOGGING_LEVEL
+  value: "INFO"
+
+- description: Number of deployment replicas
+  displayName: Number of deployment replicas
+  required: true
+  name: REPLICAS
+  value: "1"
+
+- description: User Post filters or not
+  displayName: User Post filters or not
+  required: true
+  name: USE_FILTERS
+  value: "True"
+
+- description: Restart policy
+  displayName: Restart policy
+  required: true
+  name: RESTART_POLICY
+  value: "Invalid"  # this is intentional - we don't want developers to use this template. saas-herder sets the correct value here.

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -8,74 +8,67 @@ metadata:
     description: bayesian-kronos
 objects:
 - apiVersion: v1
-  kind: DeploymentConfig
+  kind: Pod
   metadata:
     labels:
       service: bayesian-kronos-${KRONOS_SCORING_REGION}
     name: bayesian-kronos-${KRONOS_SCORING_REGION}
   spec:
-    replicas: "${{REPLICAS}}"
-    selector:
-      service: bayesian-kronos-${KRONOS_SCORING_REGION}
-    template:
-      metadata:
-        labels:
-          service: bayesian-kronos-${KRONOS_SCORING_REGION}
-      spec:
-        containers:
-        - command:
-          - /bin/entrypoint.sh
-          env:
-          - name: DEPLOYMENT_PREFIX
-            valueFrom:
-              configMapKeyRef:
-                name: bayesian-config
-                key: deployment-prefix
-          - name: SERVICE_PORT
-            value: "6006"
-          - name: SERVICE_TIMEOUT
-            value: "900"
-          - name: KRONOS_SCORING_REGION
-            value: "${KRONOS_SCORING_REGION}"
-          - name: USE_FILTERS
-            value: "${{USE_FILTERS}}"
-          - name: AWS_S3_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                key: s3-access-key-id
-                name: aws
-          - name: AWS_S3_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                key: s3-secret-access-key
-                name: aws
-          - name: FLASK_LOGGING_LEVEL
-            value: ${FLASK_LOGGING_LEVEL}
-          name: bayesian-kronos
-          image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
-          ports:
-          - containerPort: 6006
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 6006
-            initialDelaySeconds: 30
-            periodSeconds: 60
-            timeoutSeconds: 30
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 6006
-            initialDelaySeconds: 30
-            periodSeconds: 60
-            timeoutSeconds: 30
-          resources:
-            requests:
-              cpu: ${CPU_REQUEST}
-              memory: ${MEMORY_REQUEST}
-            limits:
-              cpu: ${CPU_LIMIT}
-              memory: ${MEMORY_LIMIT}
+    restartPolicy: Never
+    containers:
+    - command:
+      - /bin/entrypoint.sh
+      env:
+      - name: DEPLOYMENT_PREFIX
+        valueFrom:
+          configMapKeyRef:
+            name: bayesian-config
+            key: deployment-prefix
+      - name: SERVICE_PORT
+        value: "6006"
+      - name: SERVICE_TIMEOUT
+        value: "900"
+      - name: KRONOS_SCORING_REGION
+        value: "${KRONOS_SCORING_REGION}"
+      - name: USE_FILTERS
+        value: "${{USE_FILTERS}}"
+      - name: AWS_S3_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            key: s3-access-key-id
+            name: aws
+      - name: AWS_S3_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            key: s3-secret-access-key
+            name: aws
+      - name: FLASK_LOGGING_LEVEL
+        value: ${FLASK_LOGGING_LEVEL}
+      name: bayesian-kronos
+      image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
+      ports:
+      - containerPort: 6006
+      livenessProbe:
+        httpGet:
+          path: /
+          port: 6006
+        initialDelaySeconds: 30
+        periodSeconds: 60
+        timeoutSeconds: 30
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 6006
+        initialDelaySeconds: 30
+        periodSeconds: 60
+        timeoutSeconds: 30
+      resources:
+        requests:
+          cpu: ${CPU_REQUEST}
+          memory: ${MEMORY_REQUEST}
+        limits:
+          cpu: ${CPU_LIMIT}
+          memory: ${MEMORY_LIMIT}
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
This new template is for development purposes only. It deploys the
project as a Pod so restart policy can be set to Never. Standard
deployment configs only allow "Always" restart policy.

There is also `template-prod.yaml` which is intended for
staging/production deployments. saas-herder automatically sets restart
policy to "Always" for those environments.