### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,6 +1,6 @@
 # base image source https://github.com/rhdt/EL-Dockerfiles/blob/master/base/fabric8-analytics-stack-analysis-base/Dockerfile
 
-FROM prod.registry.devshift.net/osio-prod/base/fabric8-analytics-stack-analysis-base:latest
+FROM quay.io/openshiftio/rhel-base-fabric8-analytics-stack-analysis-base:latest
 
 # --------------------------------------------------------------------------------------------------
 # install python packages

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
+REGISTRY := quay.io
+DEFAULT_TAG=latest
+
 ifeq ($(TARGET),rhel)
   DOCKERFILE := Dockerfile.rhel
-  REGISTRY := push.registry.devshift.net/osio-prod
+  REPOSITORY := openshiftio/bayesian-kronos
 else
   DOCKERFILE := Dockerfile
-  REGISTRY := push.registry.devshift.net
+  REPOSITORY := openshiftio/rhel-bayesian-kronos
 endif
-REPOSITORY?=bayesian/kronos
-DEFAULT_TAG=latest
 
 .PHONY: all docker-build fast-docker-build get-image-name get-image-repository
 

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,12 +1,19 @@
 #!/bin/bash -ex
 
 load_jenkins_vars() {
-    if [ -e "jenkins-env" ]; then
-        <jenkins-env \
-          grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-          | sed 's/^/export /g' \
-          > ~/.jenkins-env
-        source ~/.jenkins-env
+    if [ -e "jenkins-env.json" ]; then
+        eval "$(./env-toolkit load -f jenkins-env.json \
+                DEVSHIFT_TAG_LEN \
+                QUAY_USERNAME \
+                QUAY_PASSWORD \
+                JENKINS_URL \
+                GIT_BRANCH \
+                GIT_COMMIT \
+                BUILD_NUMBER \
+                ghprbSourceBranch \
+                ghprbActualCommit \
+                BUILD_URL \
+                ghprbPullId)"
     fi
 }
 
@@ -20,8 +27,8 @@ build_image() {
     local push_registry
     push_registry=$(make get-push-registry)
     # login before build to be able to pull RHEL parent image
-    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-        docker login -u "${DEVSHIFT_USERNAME}" -p "${DEVSHIFT_PASSWORD}" "${push_registry}"
+    if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+        docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" "${push_registry}"
     else
         echo "Could not login, missing credentials for the registry"
         exit 1
@@ -44,7 +51,7 @@ push_image() {
     local push_registry
     image_name=$(make get-image-name)
     image_repository=$(make get-image-repository)
-    short_commit=$(git rev-parse --short=7 HEAD)
+    short_commit=$(git rev-parse --short=$DEVSHIFT_TAG_LEN HEAD)
     push_registry=$(make get-push-registry)
 
     if [ -n "${ghprbPullId}" ]; then

--- a/openshift/template-prod.yaml
+++ b/openshift/template-prod.yaml
@@ -119,13 +119,13 @@ parameters:
   displayName: Docker registry
   required: true
   name: DOCKER_REGISTRY
-  value: "registry.devshift.net"
+  value: "quay.io"
 
 - description: Docker image to use
   displayName: Docker image
   required: true
   name: DOCKER_IMAGE
-  value: "bayesian/kronos"
+  value: "openshiftio/rhel-bayesian-kronos"
 
 - description: Image tag
   displayName: Image tag

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -111,13 +111,13 @@ parameters:
   displayName: Docker registry
   required: true
   name: DOCKER_REGISTRY
-  value: "registry.devshift.net"
+  value: "quay.io"
 
 - description: Docker image to use
   displayName: Docker image
   required: true
   name: DOCKER_IMAGE
-  value: "bayesian/kronos"
+  value: "openshiftio/rhel-bayesian-kronos"
 
 - description: Image tag
   displayName: Image tag


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should
  not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo
to change the staging url from devshift to quay. The PR to the saas
repo should be merged before this one.
https://github.com/openshiftio/saas-analytics/pull/414