### PR TITLE
Use one central file for all QA files

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ The first script checks the indentation, line lengths, variable names, white spa
 script checks all documentation strings - its presence and format. Please fix any warnings and errors reported by these
 scripts.
 
+List of directories containing source code, that needs to be checked, are stored in a file `directories.txt`
+
 #### Code complexity measurement
 
 The scripts `measure-cyclomatic-complexity.sh` and `measure-maintainability-index.sh` are used to measure code complexity. These scripts can be run w/o any arguments:
@@ -278,6 +280,8 @@ Please note that due to Python's dynamic nature, static code analyzers are likel
 
 Because of this potential problems, only code detected with more than 90% of confidence is reported.
 
+List of directories containing source code, that needs to be checked, are stored in a file `directories.txt`
+
 #### Common issues detection
 
 The script `detect-common-errors.sh` can be used to detect common errors in the repository. This script can be run w/o any arguments:
@@ -286,7 +290,9 @@ The script `detect-common-errors.sh` can be used to detect common errors in the 
 ./detect-common-errors.sh
 ```
 
-Please note that only semantic problems are reported.
+Please note that only semantical problems are reported.
+
+List of directories containing source code, that needs to be checked, are stored in a file `directories.txt`
 
 #### Check for scripts written in BASH
 

--- a/check-docstyle.sh
+++ b/check-docstyle.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-directories="analytics_platform tagging_platform evaluation_platform util tests tools"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
 pass=0
 fail=0
 
 function prepare_venv() {
-    VIRTUALENV=$(which virtualenv)
+    VIRTUALENV="$(which virtualenv)"
     if [ $? -eq 1 ]; then
         # python34 which is in CentOS does not have virtualenv binary
-        VIRTUALENV=$(which virtualenv-3)
+        VIRTUALENV="$(which virtualenv-3)"
     fi
 
     ${VIRTUALENV} -p python3 venv && source venv/bin/activate && python3 "$(which pip3)" install pydocstyle

--- a/detect-common-errors.sh
+++ b/detect-common-errors.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-directories="analytics_platform tagging_platform evaluation_platform util tests tools"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
 pass=0
 fail=0
 
 function prepare_venv() {
-    VIRTUALENV=$(which virtualenv)
+    VIRTUALENV="$(which virtualenv)"
     if [ $? -eq 1 ]; then
         # python34 which is in CentOS does not have virtualenv binary
-        VIRTUALENV=$(which virtualenv-3)
+        VIRTUALENV="$(which virtualenv-3)"
     fi
 
     ${VIRTUALENV} -p python3 venv && source venv/bin/activate && python3 "$(which pip3)" install pyflakes
@@ -35,6 +39,7 @@ function check_files() {
     done
 }
 
+[ "$NOVENV" == "1" ] || prepare_venv || exit 1
 
 echo "----------------------------------------------------"
 echo "Checking source files for common errors in following"
@@ -42,8 +47,6 @@ echo "directories:"
 echo "$directories"
 echo "----------------------------------------------------"
 echo
-
-[ "$NOVENV" == "1" ] || prepare_venv || exit 1
 
 # checks for the whole directories
 for directory in $directories

--- a/detect-dead-code.sh
+++ b/detect-dead-code.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-directories="analytics_platform tagging_platform evaluation_platform util tests tools"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
 pass=0
 fail=0
 
 function prepare_venv() {
-    VIRTUALENV=$(which virtualenv)
+    VIRTUALENV="$(which virtualenv)"
     if [ $? -eq 1 ]; then
         # python34 which is in CentOS does not have virtualenv binary
-        VIRTUALENV=$(which virtualenv-3)
+        VIRTUALENV="$(which virtualenv-3)"
     fi
 
     ${VIRTUALENV} -p python3 venv && source venv/bin/activate && python3 "$(which pip3)" install vulture

--- a/directories.txt
+++ b/directories.txt
@@ -1,0 +1,6 @@
+analytics_platform
+tagging_platform
+evaluation_platform
+util
+tests
+tools

--- a/run-linter.sh
+++ b/run-linter.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-directories="analytics_platform tagging_platform evaluation_platform util tests tools"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
 
 pass=0
 fail=0


### PR DESCRIPTION
This PR implements the first task in:
https://jira.coreos.com/browse/APPAI-516

Make all QA-related tools more effective and easier to use by developers

1. All QA-related scripts needs to be made unified by using external list of directories to check
2. All QA-related scripts needs to be moved into separate subdirectory
3. QA Dashboard should be updated to use the new scripts (as #1)

JIRA issue for the 1st task:
https://jira.coreos.com/browse/APPAI-481

Currently, several QA-related scripts have the 'source-directories' included in the script body. It would be nice to use separate and central configuration file for this.
